### PR TITLE
feat: add ggplot2 chart builders and UI helpers

### DIFF
--- a/R/charts.R
+++ b/R/charts.R
@@ -1,0 +1,229 @@
+# Pure ggplot2 chart builder functions — no Shiny imports.
+
+library(ggplot2)
+library(dplyr)
+library(tidyr)
+library(scales)
+
+# Okabe-Ito colour-blind-safe categorical palette
+PALETTE <- c(
+  "#E69F00", "#56B4E9", "#009E73", "#F0E442",
+  "#0072B2", "#D55E00", "#CC79A7", "#334155"
+)
+
+theme_fin_health <- function() {
+  theme_minimal(base_family = "DM Sans") +
+    theme(
+      plot.background = element_rect(fill = "transparent", colour = NA),
+      panel.background = element_rect(fill = "transparent", colour = NA),
+      panel.grid.major = element_line(colour = "#e2e8f0", linewidth = 0.3),
+      panel.grid.minor = element_blank(),
+      axis.text = element_text(colour = "#475569", size = 10),
+      axis.title = element_text(colour = "#0f172a", size = 11),
+      axis.text.x = element_text(angle = -45, hjust = 0, vjust = 1),
+      plot.title = element_text(
+        colour = "#0f172a", size = 12, face = "bold",
+        margin = margin(b = 4)
+      ),
+      legend.text = element_text(colour = "#475569", size = 9),
+      legend.title = element_text(colour = "#0f172a", size = 10),
+      plot.margin = margin(5, 5, 5, 5)
+    )
+}
+
+build_sector_bar <- function(data, metric, unit) {
+  if (nrow(data) == 0) return(empty_chart())
+  avg_by_sector <- data %>%
+    group_by(Category) %>%
+    summarise(value = mean(.data[[metric]], na.rm = TRUE), .groups = "drop") %>%
+    arrange(desc(value))
+
+  if (nrow(avg_by_sector) == 0) return(empty_chart())
+
+  avg_by_sector$Category <- factor(
+    avg_by_sector$Category,
+    levels = avg_by_sector$Category
+  )
+
+  ggplot(avg_by_sector, aes(x = Category, y = value, fill = Category)) +
+    geom_col(width = 0.7) +
+    scale_fill_manual(values = PALETTE, guide = "none") +
+    labs(
+      title = paste("Average", metric, "by Sector"),
+      x = "Sector",
+      y = paste(metric, unit)
+    ) +
+    theme_fin_health()
+}
+
+build_metric_trend <- function(data, metric, unit) {
+  if (nrow(data) == 0) return(empty_chart())
+  trend <- data %>%
+    group_by(Year, Category) %>%
+    summarise(value = mean(.data[[metric]], na.rm = TRUE), .groups = "drop")
+
+  if (nrow(trend) == 0) return(empty_chart())
+
+  ggplot(trend, aes(x = factor(Year), y = value, colour = Category, group = Category)) +
+    geom_line(linewidth = 0.8) +
+    geom_point(size = 2) +
+    scale_colour_manual(values = PALETTE) +
+    labs(
+      title = paste(metric, "Trend by Sector"),
+      x = "Year",
+      y = paste(metric, unit)
+    ) +
+    theme_fin_health()
+}
+
+build_peer_scatter <- function(data, metric, unit) {
+  if (nrow(data) == 0) return(empty_chart())
+  ggplot(data, aes(x = Revenue, y = .data[[metric]], colour = Category)) +
+    geom_point(size = 3, alpha = 0.7) +
+    scale_colour_manual(values = PALETTE) +
+    scale_x_continuous(labels = comma) +
+    labs(
+      title = paste("Revenue vs", metric),
+      x = "Revenue ($)",
+      y = paste(metric, unit)
+    ) +
+    theme_fin_health() +
+    theme(axis.text.x = element_text(angle = 0, hjust = 0.5))
+}
+
+build_revenue_over_time <- function(data, company) {
+  if (nrow(data) == 0) return(empty_chart())
+  melted <- data %>%
+    select(Year, Revenue, `Net Income`) %>%
+    pivot_longer(cols = c(Revenue, `Net Income`), names_to = "Metric", values_to = "Amount")
+
+  ggplot(melted, aes(x = factor(Year), y = Amount, fill = Metric)) +
+    geom_col(position = position_dodge(width = 0.7), width = 0.6) +
+    scale_fill_manual(values = c("Revenue" = "#2563eb", "Net Income" = "#009e73")) +
+    labs(
+      title = paste("Revenue & Net Income \u2014", company),
+      x = "Year",
+      y = "$ millions"
+    ) +
+    theme_fin_health()
+}
+
+build_ratio_over_time <- function(data, company, metric) {
+  if (nrow(data) == 0) return(empty_chart())
+  ggplot(data, aes(x = factor(Year), y = .data[[metric]], group = 1)) +
+    geom_area(fill = "#2563eb", alpha = 0.08) +
+    geom_line(colour = "#2563eb", linewidth = 0.8) +
+    geom_point(colour = "#2563eb", size = 2) +
+    labs(
+      title = paste(metric, "Over Time \u2014", company),
+      x = "Year",
+      y = metric
+    ) +
+    theme_fin_health()
+}
+
+build_cash_flows <- function(data, company) {
+  if (nrow(data) == 0) return(empty_chart())
+  cf_cols <- c(
+    "Cash Flow from Operating" = "Operating",
+    "Cash Flow from Investing" = "Investing",
+    "Cash Flow from Financial Activities" = "Financing"
+  )
+  melted <- data %>%
+    select(Year, all_of(names(cf_cols))) %>%
+    pivot_longer(cols = -Year, names_to = "Flow Type", values_to = "Amount") %>%
+    mutate(`Flow Type` = cf_cols[`Flow Type`])
+
+  melted$`Flow Type` <- factor(
+    melted$`Flow Type`,
+    levels = c("Operating", "Investing", "Financing")
+  )
+
+  ggplot(melted, aes(x = factor(Year), y = Amount, fill = `Flow Type`)) +
+    geom_col(position = position_dodge(width = 0.7), width = 0.6) +
+    scale_fill_manual(values = c(
+      "Operating" = "#2563eb",
+      "Investing" = "#c0392b",
+      "Financing" = "#f59e0b"
+    )) +
+    labs(
+      title = paste("Cash Flows \u2014", company),
+      x = "Year",
+      y = "Cash Flow ($ millions)"
+    ) +
+    theme_fin_health()
+}
+
+build_company_comparison_bar <- function(data, metric, unit) {
+  if (nrow(data) == 0) return(empty_chart())
+  avg_by_company <- data %>%
+    group_by(Company) %>%
+    summarise(value = mean(.data[[metric]], na.rm = TRUE), .groups = "drop") %>%
+    arrange(desc(value))
+
+  avg_by_company$Company <- factor(
+    avg_by_company$Company,
+    levels = avg_by_company$Company
+  )
+
+  ggplot(avg_by_company, aes(x = Company, y = value, fill = Company)) +
+    geom_col(width = 0.7) +
+    scale_fill_manual(values = PALETTE, guide = "none") +
+    labs(
+      title = paste(metric, "by Company"),
+      x = "Company",
+      y = paste(metric, unit)
+    ) +
+    theme_fin_health()
+}
+
+build_single_company_summary <- function(data, metric, unit) {
+  if (nrow(data) == 0) return(empty_chart())
+  key_metrics <- c("Revenue", "Net Income", "EBITDA", "ROE", "ROA", "Net Profit Margin")
+  available <- intersect(key_metrics, colnames(data))
+  row <- data[1, ]
+  company <- row$Company
+
+  melted <- data.frame(
+    Metric = available,
+    Value = as.numeric(row[available]),
+    stringsAsFactors = FALSE
+  )
+  melted$Metric <- factor(melted$Metric, levels = rev(available))
+
+  ggplot(melted, aes(x = Value, y = Metric, fill = Metric)) +
+    geom_col() +
+    scale_fill_manual(values = PALETTE, guide = "none") +
+    labs(
+      title = paste("Key Metrics \u2014", company),
+      x = "Value",
+      y = NULL
+    ) +
+    theme_fin_health() +
+    theme(axis.text.x = element_text(angle = 0, hjust = 0.5))
+}
+
+build_company_trend <- function(data, metric, unit) {
+  if (nrow(data) == 0) return(empty_chart())
+  trend <- data %>%
+    group_by(Year, Company) %>%
+    summarise(value = mean(.data[[metric]], na.rm = TRUE), .groups = "drop")
+
+  ggplot(trend, aes(x = factor(Year), y = value, colour = Company, group = Company)) +
+    geom_line(linewidth = 0.8) +
+    geom_point(size = 2) +
+    scale_colour_manual(values = PALETTE) +
+    labs(
+      title = paste(metric, "Trend by Company"),
+      x = "Year",
+      y = paste(metric, unit)
+    ) +
+    theme_fin_health()
+}
+
+empty_chart <- function(message = "Data Unavailable") {
+  ggplot() +
+    annotate("text", x = 0.5, y = 0.5, label = message, size = 6, colour = "#475569") +
+    theme_void() +
+    xlim(0, 1) + ylim(0, 1)
+}

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -1,0 +1,61 @@
+# Reusable UI helpers: KPI card factory and status icon.
+
+library(shiny)
+library(bslib)
+
+kpi_card_ui <- function(ns, header, value_id, trend_id = NULL,
+                        label_id = NULL, status_id = NULL) {
+  value_children <- list(
+    tags$h3(
+      textOutput(ns(value_id), inline = TRUE),
+      class = "kpi-value",
+      style = "display: inline;"
+    )
+  )
+  if (!is.null(status_id)) {
+    value_children <- c(value_children, list(
+      uiOutput(ns(status_id), style = "display: inline;")
+    ))
+  }
+  if (!is.null(trend_id)) {
+    value_children <- c(value_children, list(
+      uiOutput(ns(trend_id), style = "display: inline;")
+    ))
+  }
+
+  label_row <- tags$div(
+    if (!is.null(label_id)) uiOutput(ns(label_id)) else tags$span(),
+    class = "kpi-label-row"
+  )
+
+  card(
+    card_header(header),
+    tags$div(class = "kpi-value-row", value_children),
+    label_row
+  )
+}
+
+status_icon <- function(value, healthy_threshold, warning_threshold,
+                        invert = FALSE) {
+  if (is.na(value)) return(tags$span())
+
+  if (invert) {
+    # For metrics where lower is better (e.g., Debt/Equity)
+    if (value <= healthy_threshold) {
+      return(tags$span("\u2713", class = "kpi-status healthy"))
+    } else if (value <= warning_threshold) {
+      return(tags$span("!", class = "kpi-status warning"))
+    } else {
+      return(tags$span("\u2717", class = "kpi-status danger"))
+    }
+  } else {
+    # For metrics where higher is better
+    if (value >= healthy_threshold) {
+      return(tags$span("\u2713", class = "kpi-status healthy"))
+    } else if (value >= warning_threshold) {
+      return(tags$span("!", class = "kpi-status warning"))
+    } else {
+      return(tags$span("\u2717", class = "kpi-status danger"))
+    }
+  }
+}

--- a/R/mod_company.R
+++ b/R/mod_company.R
@@ -1,0 +1,320 @@
+# Page 2: Company Financial Health — Shiny module (UI + server).
+
+library(shiny)
+library(bslib)
+library(plotly)
+
+company_ui <- function(id) {
+  ns <- NS(id)
+
+  sidebar_content <- sidebar(
+    h4("Analytics Filters"),
+    selectInput(
+      ns("category"), "Industry",
+      choices = ALL_SECTORS,
+      selected = ALL_SECTORS[1]
+    ),
+    selectInput(ns("company"), "Company", choices = NULL),
+    uiOutput(ns("year_slider")),
+    open = "desktop"
+  )
+
+  # Profitability cards
+  card_npm <- card(
+    card_header("Net Profit Margin"),
+    div(
+      tags$h3(
+        textOutput(ns("npm"), inline = TRUE),
+        class = "kpi-value", style = "display: inline;"
+      ),
+      uiOutput(ns("npm_status"), style = "display: inline;"),
+      class = "kpi-value-row"
+    ),
+    plotlyOutput(ns("npm_chart")),
+    full_screen = TRUE
+  )
+  card_roe <- card(
+    card_header("Return on Equity (ROE)"),
+    div(
+      tags$h3(
+        textOutput(ns("roe"), inline = TRUE),
+        class = "kpi-value", style = "display: inline;"
+      ),
+      uiOutput(ns("roe_status"), style = "display: inline;"),
+      class = "kpi-value-row"
+    ),
+    plotlyOutput(ns("roe_chart")),
+    full_screen = TRUE
+  )
+  card_rev_income <- card(
+    card_header("Revenue & Net Income"),
+    uiOutput(ns("rev_income_summary")),
+    plotlyOutput(ns("revenue_chart")),
+    full_screen = TRUE
+  )
+  profitability_section <- div(
+    div("PROFITABILITY", class = "section-label section-label-blue"),
+    layout_columns(
+      card_npm, card_roe, card_rev_income,
+      col_widths = c(4, 4, 4)
+    ),
+    class = "grid-section grid-section-blue"
+  )
+
+  # Financial Health cards
+  card_current_ratio <- card(
+    card_header("Current Ratio"),
+    div(
+      tags$h3(
+        textOutput(ns("current_ratio"), inline = TRUE),
+        class = "kpi-value", style = "display: inline;"
+      ),
+      uiOutput(ns("current_ratio_status"), style = "display: inline;"),
+      class = "kpi-value-row"
+    ),
+    plotlyOutput(ns("current_ratio_chart")),
+    full_screen = TRUE
+  )
+  card_debt_equity <- card(
+    card_header("Debt / Equity Ratio"),
+    div(
+      tags$h3(
+        textOutput(ns("debt_equity"), inline = TRUE),
+        class = "kpi-value", style = "display: inline;"
+      ),
+      uiOutput(ns("debt_equity_status"), style = "display: inline;"),
+      class = "kpi-value-row"
+    ),
+    plotlyOutput(ns("debt_equity_chart")),
+    full_screen = TRUE
+  )
+  card_cash_flows <- card(
+    card_header("Cash Flows"),
+    uiOutput(ns("cash_flows")),
+    plotlyOutput(ns("cash_flow_chart")),
+    full_screen = TRUE
+  )
+  health_section <- div(
+    div("FINANCIAL HEALTH", class = "section-label section-label-red"),
+    layout_columns(
+      card_current_ratio, card_debt_equity, card_cash_flows,
+      col_widths = c(4, 4, 4)
+    ),
+    class = "grid-section grid-section-red"
+  )
+
+  layout_sidebar(
+    sidebar = sidebar_content,
+    h2("Financial Health Dashboard"),
+    profitability_section,
+    health_section
+  )
+}
+
+company_server <- function(id) {
+  moduleServer(id, function(input, output, session) {
+    ns <- session$ns
+
+    # Update company choices when category changes
+    observeEvent(input$category, {
+      companies <- CATEGORY_COMPANIES[[input$category]]
+      if (is.null(companies)) companies <- character(0)
+      selected <- if (length(companies) > 0) companies[1] else NULL
+      updateSelectInput(session, "company", choices = companies, selected = selected)
+    })
+
+    # Dynamic year slider
+    output$year_slider <- renderUI({
+      company <- input$company
+      req(company)
+      company_data <- df %>% filter(Company == company)
+      if (nrow(company_data) == 0) {
+        yr_min <- min(df$Year)
+        yr_max <- max(df$Year)
+      } else {
+        yr_min <- min(company_data$Year)
+        yr_max <- max(company_data$Year)
+      }
+      if (yr_min == yr_max) {
+        div(
+          tags$label("Year", class = "control-label"),
+          tags$p(as.character(yr_max), style = "font-weight: 600; font-size: 1.1rem;")
+        )
+      } else {
+        sliderInput(ns("year"), "Year",
+          min = yr_min, max = yr_max,
+          value = yr_max, sep = ""
+        )
+      }
+    })
+
+    # Filtered data (single company, single year)
+    filtered_data <- reactive({
+      req(input$category, input$company, input$year)
+      df %>%
+        filter(
+          Category == input$category,
+          Company == input$company,
+          Year == input$year
+        )
+    })
+
+    # Full company data (all years, for trend charts)
+    company_data <- reactive({
+      req(input$company)
+      df %>% filter(Company == input$company)
+    })
+
+    # --- Profitability KPIs ---
+    output$npm <- renderText({
+      fd <- filtered_data()
+      if (nrow(fd) == 0) return("N/A")
+      sprintf("%.1f%%", fd$`Net Profit Margin`[1])
+    })
+
+    output$roe <- renderText({
+      fd <- filtered_data()
+      if (nrow(fd) == 0) return("N/A")
+      sprintf("%.2f%%", fd$ROE[1])
+    })
+
+    output$npm_status <- renderUI({
+      fd <- filtered_data()
+      if (nrow(fd) == 0) return(tags$span())
+      status_icon(fd$`Net Profit Margin`[1], 10, 0)
+    })
+
+    output$roe_status <- renderUI({
+      fd <- filtered_data()
+      if (nrow(fd) == 0) return(tags$span())
+      status_icon(fd$ROE[1], 15, 0)
+    })
+
+    output$npm_chart <- renderPlotly({
+      cd <- company_data()
+      if (nrow(cd) == 0) return(ggplotly(empty_chart()))
+      ggplotly(
+        build_ratio_over_time(cd, input$company, "Net Profit Margin"),
+        tooltip = "text"
+      ) %>%
+        config(displayModeBar = FALSE) %>%
+        layout(xaxis = list(fixedrange = TRUE), yaxis = list(fixedrange = TRUE))
+    })
+
+    output$roe_chart <- renderPlotly({
+      cd <- company_data()
+      if (nrow(cd) == 0) return(ggplotly(empty_chart()))
+      ggplotly(
+        build_ratio_over_time(cd, input$company, "ROE"),
+        tooltip = "text"
+      ) %>%
+        config(displayModeBar = FALSE) %>%
+        layout(xaxis = list(fixedrange = TRUE), yaxis = list(fixedrange = TRUE))
+    })
+
+    output$rev_income_summary <- renderUI({
+      fd <- filtered_data()
+      if (nrow(fd) == 0) return(div("N/A"))
+      rev <- fd$Revenue[1]
+      ni <- fd$`Net Income`[1]
+      div(
+        span(sprintf("Revenue: $%sM", formatC(rev, format = "f", big.mark = ",", digits = 0)),
+          class = "kpi-label"
+        ),
+        span(" | ", style = "color: var(--slate-400);"),
+        span(sprintf("Net Income: $%sM", formatC(ni, format = "f", big.mark = ",", digits = 0)),
+          class = "kpi-label"
+        ),
+        style = "padding: 0.25rem 0; text-align: center;"
+      )
+    })
+
+    output$revenue_chart <- renderPlotly({
+      cd <- company_data()
+      if (nrow(cd) == 0) return(ggplotly(empty_chart()))
+      ggplotly(
+        build_revenue_over_time(cd, input$company),
+        tooltip = "text"
+      ) %>%
+        config(displayModeBar = FALSE) %>%
+        layout(xaxis = list(fixedrange = TRUE), yaxis = list(fixedrange = TRUE))
+    })
+
+    # --- Financial Health KPIs ---
+    output$current_ratio <- renderText({
+      fd <- filtered_data()
+      if (nrow(fd) == 0) return("N/A")
+      sprintf("%.2f", fd$`Current Ratio`[1])
+    })
+
+    output$current_ratio_status <- renderUI({
+      fd <- filtered_data()
+      if (nrow(fd) == 0) return(tags$span())
+      status_icon(fd$`Current Ratio`[1], 1.5, 1.0)
+    })
+
+    output$current_ratio_chart <- renderPlotly({
+      cd <- company_data()
+      if (nrow(cd) == 0) return(ggplotly(empty_chart()))
+      ggplotly(
+        build_ratio_over_time(cd, input$company, "Current Ratio"),
+        tooltip = "text"
+      ) %>%
+        config(displayModeBar = FALSE) %>%
+        layout(xaxis = list(fixedrange = TRUE), yaxis = list(fixedrange = TRUE))
+    })
+
+    output$debt_equity <- renderText({
+      fd <- filtered_data()
+      if (nrow(fd) == 0) return("N/A")
+      sprintf("%.2f", fd$`Debt/Equity Ratio`[1])
+    })
+
+    output$debt_equity_status <- renderUI({
+      fd <- filtered_data()
+      if (nrow(fd) == 0) return(tags$span())
+      status_icon(fd$`Debt/Equity Ratio`[1], 1.0, 2.0, invert = TRUE)
+    })
+
+    output$debt_equity_chart <- renderPlotly({
+      cd <- company_data()
+      if (nrow(cd) == 0) return(ggplotly(empty_chart()))
+      ggplotly(
+        build_ratio_over_time(cd, input$company, "Debt/Equity Ratio"),
+        tooltip = "text"
+      ) %>%
+        config(displayModeBar = FALSE) %>%
+        layout(xaxis = list(fixedrange = TRUE), yaxis = list(fixedrange = TRUE))
+    })
+
+    output$cash_flows <- renderUI({
+      fd <- filtered_data()
+      if (nrow(fd) == 0) return(div("N/A"))
+      row <- fd[1, ]
+      op <- row$`Cash Flow from Operating`
+      inv <- row$`Cash Flow from Investing`
+      fin <- row$`Cash Flow from Financial Activities`
+      fmt <- function(v) {
+        if (v < 0) paste0("-$", formatC(abs(v), format = "f", big.mark = ",", digits = 0), "M")
+        else paste0("$", formatC(v, format = "f", big.mark = ",", digits = 0), "M")
+      }
+      div(
+        span(paste("Operating:", fmt(op)), class = "kpi-label"), br(),
+        span(paste("Investing:", fmt(inv)), class = "kpi-label"), br(),
+        span(paste("Financing:", fmt(fin)), class = "kpi-label"),
+        style = "text-align: center;"
+      )
+    })
+
+    output$cash_flow_chart <- renderPlotly({
+      cd <- company_data()
+      if (nrow(cd) == 0) return(ggplotly(empty_chart()))
+      ggplotly(
+        build_cash_flows(cd, input$company),
+        tooltip = "text"
+      ) %>%
+        config(displayModeBar = FALSE) %>%
+        layout(xaxis = list(fixedrange = TRUE), yaxis = list(fixedrange = TRUE))
+    })
+  })
+}

--- a/R/mod_sector.R
+++ b/R/mod_sector.R
@@ -1,0 +1,278 @@
+# Page 1: Sector Analysis — Shiny module (UI + server).
+
+library(shiny)
+library(bslib)
+library(plotly)
+library(DT)
+
+sector_ui <- function(id) {
+  ns <- NS(id)
+
+  # Sidebar inputs
+  sidebar_content <- sidebar(
+    h4("Analytics Filters"),
+    sliderInput(
+      ns("year_range"), "Period",
+      min = min(df$Year), max = max(df$Year),
+      value = c(min(df$Year), max(df$Year)),
+      sep = ""
+    ),
+    selectizeInput(
+      ns("sector"), "Sector",
+      choices = c("All", ALL_SECTORS),
+      selected = "All",
+      multiple = TRUE
+    ),
+    selectizeInput(
+      ns("metric"), "Metric",
+      choices = names(METRIC_CHOICES),
+      selected = "Net Profit Margin"
+    ),
+    actionButton(ns("reset"), "Reset Filters"),
+    open = "desktop"
+  )
+
+  # KPI cards
+  card_avg_margin <- kpi_card_ui(
+    ns, "Avg Profit Margin",
+    value_id = "avg_margin",
+    trend_id = "margin_trend",
+    label_id = "margin_badge"
+  )
+  card_top_sector <- kpi_card_ui(
+    ns, "Top Sector",
+    value_id = "top_sector",
+    label_id = "index_performance"
+  )
+  card_revenue_growth <- kpi_card_ui(
+    ns, "Revenue Growth",
+    value_id = "revenue_growth_value",
+    trend_id = "revenue_trend",
+    label_id = "revenue_growth_label"
+  )
+  kpi_row <- div(
+    layout_columns(
+      card_avg_margin, card_top_sector, card_revenue_growth,
+      col_widths = c(4, 4, 4)
+    ),
+    class = "kpi-card-row"
+  )
+
+  # Chart cards
+  chart_row <- layout_columns(
+    card(
+      card_header("Sector Comparison"),
+      plotlyOutput(ns("chart_a")),
+      full_screen = TRUE
+    ),
+    card(
+      card_header("Historical Trend"),
+      plotlyOutput(ns("chart_b")),
+      full_screen = TRUE
+    ),
+    col_widths = c(6, 6)
+  )
+
+  # Peer + Table
+  peer_row <- layout_columns(
+    card(
+      card_header("Peer Benchmarking"),
+      plotlyOutput(ns("chart_c")),
+      full_screen = TRUE
+    ),
+    card(
+      card_header("Company Details"),
+      DTOutput(ns("table_d"))
+    ),
+    col_widths = c(6, 6)
+  )
+
+  layout_sidebar(
+    sidebar = sidebar_content,
+    h2("US Corporate Profitability Analytics"),
+    kpi_row,
+    chart_row,
+    peer_row
+  )
+}
+
+sector_server <- function(id) {
+  moduleServer(id, function(input, output, session) {
+    ns <- session$ns
+
+    # Selected metric with fallback
+    selected_metric <- reactive({
+      m <- input$metric
+      if (is.null(m) || !(m %in% names(METRIC_CHOICES))) {
+        return("Net Profit Margin")
+      }
+      m
+    })
+
+    # Reset filters
+    observeEvent(input$reset, {
+      updateSliderInput(session, "year_range",
+        value = c(min(df$Year), max(df$Year))
+      )
+      updateSelectizeInput(session, "sector", selected = "All")
+      updateSelectizeInput(session, "metric", selected = "Net Profit Margin")
+    })
+
+    # Filtered data
+    filtered_data <- reactive({
+      yr <- input$year_range
+      sectors <- input$sector
+      filtered <- df %>%
+        filter(Year >= yr[1], Year <= yr[2])
+      if (!is.null(sectors) && !("All" %in% sectors)) {
+        filtered <- filtered %>% filter(Category %in% sectors)
+      }
+      filtered
+    })
+
+    # --- KPI: Avg Profit Margin ---
+    output$avg_margin <- renderText({
+      fd <- filtered_data()
+      if (nrow(fd) == 0) return("Data Unavailable")
+      avg <- mean(fd$`Net Profit Margin`, na.rm = TRUE)
+      sprintf("%.1f%%", avg)
+    })
+
+    output$margin_trend <- renderUI({
+      fd <- filtered_data()
+      if (nrow(fd) == 0) return(tags$span())
+      years <- sort(unique(fd$Year))
+      if (length(years) < 2) return(tags$span())
+      current <- mean(fd$`Net Profit Margin`[fd$Year == tail(years, 1)], na.rm = TRUE)
+      previous <- mean(fd$`Net Profit Margin`[fd$Year == years[length(years) - 1]], na.rm = TRUE)
+      if (is.na(current) || is.na(previous)) return(tags$span())
+      is_positive <- current >= previous
+      trend_char <- if (is_positive) "\u25b2" else "\u25bc"
+      trend_class <- if (is_positive) "up" else "down"
+      tags$span(trend_char, class = paste("trend-indicator", trend_class))
+    })
+
+    output$margin_badge <- renderUI({
+      fd <- filtered_data()
+      if (nrow(fd) == 0) return(tags$span())
+      n <- length(unique(fd$Company))
+      tags$p(
+        paste("BASED ON", n, "COMPANIES"),
+        class = "kpi-label",
+        style = "margin-top: 0.5rem;"
+      )
+    })
+
+    # --- KPI: Top Sector ---
+    output$top_sector <- renderText({
+      fd <- filtered_data()
+      if (nrow(fd) == 0) return("Data Unavailable")
+      top <- fd %>%
+        group_by(Category) %>%
+        summarise(avg = mean(`Net Profit Margin`, na.rm = TRUE), .groups = "drop") %>%
+        slice_max(avg, n = 1)
+      top$Category[1]
+    })
+
+    index_margin <- reactive({
+      fd <- filtered_data()
+      if (nrow(fd) == 0) return(0)
+      total_revenue <- sum(fd$Revenue, na.rm = TRUE)
+      total_net_income <- sum(fd$`Net Income`, na.rm = TRUE)
+      if (total_revenue == 0) return(0)
+      (total_net_income / total_revenue) * 100
+    })
+
+    output$index_performance <- renderUI({
+      margin <- index_margin()
+      tags$p(
+        "INDEX PERFORMANCE: ",
+        tags$strong(sprintf("%.1f%%", margin)),
+        " NET PROFIT MARGIN",
+        class = "kpi-label"
+      )
+    })
+
+    # --- KPI: Revenue Growth ---
+    revenue_change <- reactive({
+      fd <- filtered_data()
+      yearly_rev <- fd %>%
+        group_by(Year) %>%
+        summarise(total = sum(Revenue, na.rm = TRUE), .groups = "drop") %>%
+        arrange(desc(Year))
+      if (nrow(yearly_rev) < 2) return(NULL)
+      current <- yearly_rev$total[1]
+      previous <- yearly_rev$total[2]
+      if (is.na(current) || is.na(previous) || previous == 0) return(NULL)
+      growth <- (current - previous) / previous * 100
+      list(value = growth, is_positive = growth >= 0)
+    })
+
+    output$revenue_growth_value <- renderText({
+      change <- revenue_change()
+      if (is.null(change)) return("Data Unavailable")
+      sign <- if (change$is_positive) "+" else ""
+      sprintf("%s%.1f%%", sign, change$value)
+    })
+
+    output$revenue_growth_label <- renderUI({
+      tags$p("YEAR OVER YEAR", class = "kpi-label", style = "margin-top: 0.5rem;")
+    })
+
+    output$revenue_trend <- renderUI({
+      change <- revenue_change()
+      if (is.null(change)) return(tags$span())
+      trend_char <- if (change$is_positive) "\u25b2" else "\u25bc"
+      trend_class <- if (change$is_positive) "up" else "down"
+      tags$span(trend_char, class = paste("trend-indicator", trend_class))
+    })
+
+    # --- Charts ---
+    output$chart_a <- renderPlotly({
+      fd <- filtered_data()
+      metric <- selected_metric()
+      unit <- METRIC_CHOICES[metric]
+      ggplotly(build_sector_bar(fd, metric, unit), tooltip = "text") %>%
+        config(displayModeBar = FALSE) %>%
+        layout(
+          xaxis = list(fixedrange = TRUE),
+          yaxis = list(fixedrange = TRUE)
+        )
+    })
+
+    output$chart_b <- renderPlotly({
+      fd <- filtered_data()
+      metric <- selected_metric()
+      unit <- METRIC_CHOICES[metric]
+      ggplotly(build_metric_trend(fd, metric, unit)) %>%
+        config(displayModeBar = FALSE) %>%
+        layout(
+          xaxis = list(fixedrange = TRUE),
+          yaxis = list(fixedrange = TRUE)
+        )
+    })
+
+    output$chart_c <- renderPlotly({
+      fd <- filtered_data()
+      metric <- selected_metric()
+      unit <- METRIC_CHOICES[metric]
+      ggplotly(build_peer_scatter(fd, metric, unit)) %>%
+        config(displayModeBar = FALSE) %>%
+        layout(
+          xaxis = list(fixedrange = TRUE),
+          yaxis = list(fixedrange = TRUE)
+        )
+    })
+
+    # --- Table ---
+    output$table_d <- renderDT({
+      fd <- filtered_data()
+      cols <- c("Company", "Category", "Year", "Revenue", "Net Income", "Net Profit Margin")
+      datatable(
+        fd[, cols],
+        options = list(pageLength = 10, scrollX = TRUE),
+        rownames = FALSE
+      )
+    })
+  })
+}


### PR DESCRIPTION
## Summary
- Add `R/charts.R` with 9 ggplot2 chart builder functions + custom `theme_fin_health()` + Okabe-Ito palette
- Add `R/helpers.R` with `kpi_card_ui()` factory and `status_icon()` helper

## Chart functions
`build_sector_bar()`, `build_metric_trend()`, `build_peer_scatter()`, `build_revenue_over_time()`, `build_ratio_over_time()`, `build_cash_flows()`, `build_company_comparison_bar()`, `build_single_company_summary()`, `build_company_trend()`, `empty_chart()`

## Test plan
- [ ] Charts render correctly when called with sample data
- [ ] `kpi_card_ui()` returns valid bslib card
- [ ] `status_icon()` returns correct classes for healthy/warning/danger thresholds

Closes #2