### PR TITLE
feat: add fin-chat (AI Explorer) page module

### DIFF
--- a/R/mod_ai_explorer.R
+++ b/R/mod_ai_explorer.R
@@ -1,0 +1,312 @@
+# Page 3: fin-chat — natural-language data filtering with querychat (R).
+
+library(shiny)
+library(bslib)
+library(plotly)
+library(DT)
+
+DEFAULT_METRIC <- "Net Profit Margin"
+
+# Keyword -> metric mapping for inferring metric from querychat title/SQL.
+METRIC_KEYWORDS <- c(
+  "net profit margin" = "Net Profit Margin",
+  "profit margin" = "Net Profit Margin",
+  "roe" = "ROE",
+  "return on equity" = "ROE",
+  "roa" = "ROA",
+  "return on assets" = "ROA",
+  "roi" = "ROI",
+  "return on investment" = "ROI",
+  "revenue" = "Revenue",
+  "net income" = "Net Income",
+  "ebitda" = "EBITDA",
+  "current ratio" = "Current Ratio",
+  "debt/equity" = "Debt/Equity Ratio",
+  "debt equity" = "Debt/Equity Ratio",
+  "debt to equity" = "Debt/Equity Ratio"
+)
+
+infer_metric <- function(title) {
+  if (is.null(title) || title == "") return(DEFAULT_METRIC)
+  lower <- tolower(title)
+  for (keyword in names(METRIC_KEYWORDS)) {
+    if (grepl(keyword, lower, fixed = TRUE)) {
+      return(METRIC_KEYWORDS[[keyword]])
+    }
+  }
+  DEFAULT_METRIC
+}
+
+DATA_DESCRIPTION <- "
+US Corporate financial statement data (2009-2023), covering 12 publicly
+traded companies across 8 sectors.
+
+Company-sector mapping:
+- BANK: AIG, BCS
+- ELEC: INTC, NVDA
+- FINANCE: SHLDQ
+- FINTECH: PYPL
+- FOOD: MCD
+- IT: AAPL, GOOG, MSFT
+- LOGI: AMZN
+- MANUFACTURING: PCG
+
+Column descriptions (with approximate value ranges):
+- Year: fiscal year (2009-2023)
+- Company: ticker symbol (AAPL, GOOG, MSFT, AMZN, INTC, NVDA, PYPL, MCD, AIG, BCS, SHLDQ, PCG)
+- Category: sector (BANK, ELEC, FINANCE, FINTECH, FOOD, IT, LOGI, MANUFACTURING)
+- Market Cap(in B USD): market capitalization in billions (~$1B-$3,000B)
+- Revenue: annual revenue in millions USD (~$500M-$400,000M)
+- Gross Profit: gross profit in millions USD (~$100M-$170,000M)
+- Net Income: net income in millions USD (~-$25,000M-$100,000M)
+- Earning Per Share: earnings per share in USD (~-$30-$6)
+- EBITDA: earnings before interest, taxes, depreciation, amortization in millions USD (~-$5,000M-$130,000M)
+- Share Holder Equity: total shareholder equity in millions USD (~-$15,000M-$270,000M)
+- Cash Flow from Operating: operating cash flow in millions USD (~-$5,000M-$120,000M)
+- Cash Flow from Investing: investing cash flow in millions USD (~-$50,000M-$30,000M)
+- Cash Flow from Financial Activities: financing cash flow in millions USD (~-$120,000M-$30,000M)
+- Current Ratio: current assets / current liabilities; >1 = healthy liquidity (~0.5-4.0)
+- Debt/Equity Ratio: total debt / shareholder equity (~-10-30)
+- ROE: return on equity in percent (~-80%-+160%)
+- ROA: return on assets in percent (~-15%-+30%)
+- ROI: return on investment in percent (~-20%-+50%)
+- Net Profit Margin: net income / revenue in percent (~-50%-+35%)
+- Free Cash Flow per Share: free cash flow per share in USD (~-$5-$7)
+- Return on Tangible Equity: return on tangible equity in percent (~-200%-+200%)
+- Number of Employees: headcount (~10,000-1,600,000)
+- Inflation Rate(in US): US inflation rate for that year in percent (~0.1%-8%)
+"
+
+GREETING <- '
+Hi! I can help you explore the financial dataset. Try one of these:
+
+**Filter:** <span class="suggestion">Show tech companies with net profit margin above 20%</span>
+
+**Compare:** <span class="suggestion">Rank all companies by ROE in 2022</span>
+
+**Aggregate:** <span class="suggestion">What is the average revenue by sector?</span>
+
+**Health check:** <span class="suggestion">Which companies have a current ratio below 1?</span>
+'
+
+EXTRA_INSTRUCTIONS <- '
+You are a financial data analyst assistant. Follow these rules strictly:
+
+1. **Tool selection rules - read carefully:**
+   - Use `querychat_query` for any question needing aggregation (GROUP BY, AVG,
+     SUM, COUNT, ranking, TOP N, etc.) or when reporting statistics.
+   - Use `querychat_update_dashboard` ONLY for filtering the dashboard.
+   - **CRITICAL: `querychat_update_dashboard` queries MUST always start with
+     `SELECT * FROM financial_data WHERE ...`.**  Never select specific columns.
+     Never use GROUP BY, CTEs, JOINs, or subqueries. The query must return
+     every column in the table or it will fail.
+   - Never guess or hallucinate numbers. If you cannot answer from the data,
+     say so.
+
+2. **Always quote column names** that contain spaces, slashes, or parentheses
+   with double quotes in SQL. For example: "Current Ratio", "Debt/Equity Ratio",
+   "Market Cap(in B USD)", "Cash Flow from Operating", "Earning Per Share",
+   "Cash Flow from Investing", "Cash Flow from Financial Activities",
+   "Inflation Rate(in US)", "Share Holder Equity", "Net Profit Margin",
+   "Free Cash Flow per Share", "Return on Tangible Equity",
+   "Number of Employees", "Gross Profit", "Net Income".
+
+3. Structure every response in this format:
+   - **Filters applied:** list the filters used (or "None" if showing all data)
+   - **Key stats:** 2-3 notable numbers from the query result
+   - **Insight:** one sentence interpreting the result
+   - **Try next:** one clickable follow-up suggestion as
+     `<span class="suggestion">suggestion text</span>`
+
+4. When the user asks about a sector, use the Category column (e.g., IT, BANK).
+   When they mention a company name, map it to the ticker in the Company column.
+
+5. Keep responses concise - no more than 5 sentences outside the structured format.
+
+6. **Never include raw HTML, SQL code blocks, or `<button>` markup in your
+   response text.** Do not echo the SQL query or the button element back to the
+   user. Just call the appropriate tool and provide the structured summary.
+'
+
+has_token <- function() {
+  nzchar(Sys.getenv("GITHUB_TOKEN", ""))
+}
+
+ai_explorer_ui <- function(id) {
+  ns <- NS(id)
+
+  if (!has_token()) {
+    return(
+      div(
+        h2("fin-chat"),
+        card(
+          card_header("Configuration Required"),
+          p("Set the GITHUB_TOKEN environment variable to enable fin-chat.")
+        )
+      )
+    )
+  }
+
+  sidebar_content <- sidebar(
+    querychat::querychat_ui(ns("qc")),
+    open = "desktop",
+    width = 400
+  )
+
+  data_card <- card(
+    card_header(
+      div(
+        div(
+          textOutput(ns("ai_title"), inline = TRUE),
+          span(" | "),
+          textOutput(ns("ai_row_count"), inline = TRUE)
+        ),
+        downloadButton(
+          ns("ai_download"),
+          span(
+            HTML(
+              '<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14"
+               viewBox="0 0 24 24" fill="none" stroke="currentColor"
+               stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
+               style="vertical-align: -1px; margin-right: 4px;">
+               <path d="M19 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11l5 5v11a2 2 0 0 1-2 2z"/>
+               <polyline points="17 21 17 13 7 13 7 21"/>
+               <polyline points="7 3 7 8 15 8"/>
+               </svg>'
+            ),
+            "Download CSV"
+          ),
+          class = "btn-sm btn-csv-download"
+        ),
+        class = "d-flex justify-content-between align-items-center w-100"
+      )
+    ),
+    DTOutput(ns("ai_data_table")),
+    full_screen = TRUE
+  )
+
+  chart_row <- layout_columns(
+    card(
+      card_header("Sector Profitability"),
+      plotlyOutput(ns("ai_chart_a")),
+      full_screen = TRUE
+    ),
+    card(
+      card_header("Metric Trend"),
+      plotlyOutput(ns("ai_chart_b")),
+      full_screen = TRUE
+    ),
+    col_widths = c(6, 6)
+  )
+
+  layout_sidebar(
+    sidebar = sidebar_content,
+    h2("fin-chat"),
+    data_card,
+    chart_row
+  )
+}
+
+ai_explorer_server <- function(id) {
+  moduleServer(id, function(input, output, session) {
+    ns <- session$ns
+
+    if (!has_token()) return()
+
+    qc <- querychat::querychat_server(
+      "qc",
+      df,
+      table_name = "financial_data",
+      data_description = DATA_DESCRIPTION,
+      extra_instructions = EXTRA_INSTRUCTIONS,
+      greeting = GREETING,
+      create_chat_client = function() {
+        ellmer::chat_github(model = "gpt-4.1-mini")
+      }
+    )
+
+    output$ai_title <- renderText({
+      title <- qc$title()
+      if (is.null(title) || title == "") "Filtered Data" else title
+    })
+
+    output$ai_row_count <- renderText({
+      filtered <- qc$df()
+      paste(nrow(filtered), "rows")
+    })
+
+    output$ai_data_table <- renderDT({
+      filtered <- qc$df()
+      datatable(
+        head(filtered, 10),
+        options = list(
+          pageLength = 10,
+          scrollX = TRUE,
+          dom = "t"
+        ),
+        rownames = FALSE
+      )
+    })
+
+    output$ai_download <- downloadHandler(
+      filename = function() "filtered_financial_data.csv",
+      content = function(file) {
+        write.csv(qc$df(), file, row.names = FALSE)
+      }
+    )
+
+    # Helper to determine data shape
+    data_shape <- function(filtered) {
+      list(
+        n_companies = length(unique(filtered$Company)),
+        n_sectors = length(unique(filtered$Category)),
+        n_years = length(unique(filtered$Year))
+      )
+    }
+
+    output$ai_chart_a <- renderPlotly({
+      filtered <- qc$df()
+      metric <- infer_metric(qc$title())
+      unit <- METRIC_CHOICES[metric]
+      if (nrow(filtered) == 0) return(ggplotly(empty_chart()))
+
+      shape <- data_shape(filtered)
+      p <- if (shape$n_companies == 1) {
+        build_single_company_summary(filtered, metric, unit)
+      } else if (shape$n_sectors == 1 || shape$n_years == 1) {
+        build_company_comparison_bar(filtered, metric, unit)
+      } else {
+        build_sector_bar(filtered, metric, unit)
+      }
+      ggplotly(p) %>%
+        config(displayModeBar = FALSE) %>%
+        layout(xaxis = list(fixedrange = TRUE), yaxis = list(fixedrange = TRUE))
+    })
+
+    output$ai_chart_b <- renderPlotly({
+      filtered <- qc$df()
+      metric <- infer_metric(qc$title())
+      unit <- METRIC_CHOICES[metric]
+      if (nrow(filtered) == 0) return(ggplotly(empty_chart()))
+
+      shape <- data_shape(filtered)
+      p <- if (shape$n_companies == 1) {
+        company <- filtered$Company[1]
+        if (shape$n_years > 1) {
+          build_company_trend(filtered, metric, unit)
+        } else {
+          build_cash_flows(filtered, company)
+        }
+      } else if (shape$n_years == 1) {
+        build_peer_scatter(filtered, metric, unit)
+      } else if (shape$n_companies <= 5) {
+        build_company_trend(filtered, metric, unit)
+      } else {
+        build_metric_trend(filtered, metric, unit)
+      }
+      ggplotly(p) %>%
+        config(displayModeBar = FALSE) %>%
+        layout(xaxis = list(fixedrange = TRUE), yaxis = list(fixedrange = TRUE))
+    })
+  })
+}

--- a/app.R
+++ b/app.R
@@ -3,8 +3,13 @@
 library(shiny)
 library(bslib)
 
-# Source modules
+# Source all R modules
 source("R/data.R")
+source("R/charts.R")
+source("R/helpers.R")
+source("R/mod_sector.R")
+source("R/mod_company.R")
+source("R/mod_ai_explorer.R")
 
 # Custom CSS
 css_tag <- tags$link(rel = "stylesheet", href = "custom_styles.css")
@@ -15,9 +20,9 @@ ui <- page_navbar(
   id = "main_nav",
   fillable = TRUE,
   header = css_tag,
-  nav_panel("Sector Analysis", h3("Sector Analysis — coming soon")),
-  nav_panel("Company Health", h3("Company Health — coming soon")),
-  nav_panel("fin-chat", h3("fin-chat — coming soon")),
+  nav_panel("Sector Analysis", sector_ui("sector")),
+  nav_panel("Company Health", company_ui("company")),
+  nav_panel("fin-chat", ai_explorer_ui("ai")),
   footer = tags$footer(
     tags$div(
       tags$p(
@@ -32,7 +37,9 @@ ui <- page_navbar(
 )
 
 server <- function(input, output, session) {
-  # Module servers will be added here
+  sector_server("sector")
+  company_server("company")
+  ai_explorer_server("ai")
 }
 
 shinyApp(ui, server)


### PR DESCRIPTION
## Summary
- Add `R/mod_ai_explorer.R` with `ai_explorer_ui()` and `ai_explorer_server()` Shiny module
- Uses R's `querychat` package with `ellmer::chat_github(model = "gpt-4.1-mini")`
- Sidebar: querychat chat UI for natural language data queries
- Main panel: data table (DT, limited to 10 rows), download CSV button, 2 adaptive charts
- Adaptive chart selection: single company -> summary, single sector/year -> comparison bar, multiple -> sector/trend
- Metric inference from query title via keyword matching
- `GITHUB_TOKEN` check with fallback UI when missing
- Update `app.R` to wire all 3 module servers

## Test plan
- [ ] fin-chat page renders (with and without GITHUB_TOKEN)
- [ ] Chat queries return filtered data and update table/charts
- [ ] CSV download works
- [ ] Adaptive charts select correct chart type based on data shape

Closes #5