### PR TITLE
feat: adapt CSS for R Shiny (plotly containers, remove Altair selectors)

### DIFF
--- a/www/custom_styles.css
+++ b/www/custom_styles.css
@@ -1,0 +1,632 @@
+@import url('https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;600;700&display=swap');
+
+:root {
+    --primary: #2563eb;
+    --primary-light: #60a5fa;
+    --success: #009e73;
+    --danger: #d55e00;
+    --warning: #f59e0b;
+    --info: #56b4e9;
+    --slate-50: #f8fafc;
+    --slate-100: #f1f5f9;
+    --slate-200: #e2e8f0;
+    --slate-400: #cbd5e1;
+    --slate-600: #475569;
+    --slate-700: #334155;
+    --slate-900: #0f172a;
+    --section-blue: #2980b9;
+    --section-red: #c0392b;
+}
+
+html, body {
+    height: 100%;
+    margin: 0;
+    overflow: hidden;
+    font-family: 'DM Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    background-color: var(--slate-50);
+}
+
+/* Viewport-contained app layout */
+body > .container-fluid {
+    display: flex;
+    flex-direction: column;
+    height: 100vh;
+    overflow: hidden;
+}
+
+/* Navbar stays fixed at top */
+body > .container-fluid > .navbar {
+    flex-shrink: 0;
+}
+
+/* Tab content fills remaining space — no scroll */
+body > .container-fluid > .navbar + .container-fluid,
+body > .container-fluid > .tab-content,
+.navbar + .container-fluid {
+    flex: 1 1 auto;
+    overflow: hidden;
+    min-height: 0;
+}
+
+/* Footer pinned at bottom */
+body > .container-fluid > footer {
+    flex-shrink: 0;
+}
+
+h2 {
+    font-family: 'DM Sans', sans-serif;
+    font-weight: 700;
+    color: var(--slate-900);
+    margin-bottom: 0.25rem;
+    letter-spacing: -0.02em;
+    font-size: clamp(1rem, 1.8vw, 1.5rem);
+    flex-shrink: 0;
+}
+
+h3, h4 {
+    font-weight: 600;
+    color: var(--slate-900);
+}
+
+.sidebar {
+    background-color: white;
+    border-right: 1px solid var(--slate-200);
+    box-shadow: 1px 0 3px rgba(0, 0, 0, 0.05);
+    max-height: calc(100vh - 80px);
+    overflow-y: auto;
+}
+
+.sidebar h4 {
+    font-size: 0.875rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    color: var(--slate-700);
+    margin-bottom: 1.5rem;
+}
+
+/* Card Styling — flat, clean, flex-fill */
+.card {
+    border: 1px solid var(--slate-200);
+    border-radius: 0.75rem;
+    box-shadow: none;
+    background-color: white;
+    position: relative;
+    overflow: hidden;
+    transition: box-shadow 0.2s ease;
+    min-height: 0;
+    display: flex;
+    flex-direction: column;
+    flex: 1 1 0;
+}
+
+.card:hover {
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
+}
+
+.card-header {
+    background-color: transparent;
+    border-bottom: none;
+    padding: clamp(0.25rem, 0.5vh, 0.5rem) clamp(0.5rem, 1vw, 1rem) 0;
+    flex-shrink: 0;
+}
+
+.card-header .card-title,
+.card-header h5 {
+    font-size: clamp(0.55rem, 0.8vw, 0.7rem);
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.15em;
+    color: var(--slate-600);
+    margin: 0;
+}
+
+.card-body {
+    padding: clamp(0.15rem, 0.3vh, 0.25rem) clamp(0.5rem, 1vw, 1rem) clamp(0.25rem, 0.5vh, 0.5rem);
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    flex: 1 1 0;
+    min-height: 0;
+    overflow: hidden;
+}
+
+/* KPI Value Styling — large and prominent, scales with viewport */
+.kpi-value {
+    font-family: 'DM Sans', sans-serif;
+    font-size: clamp(1.2rem, 2.5vw, 2rem);
+    font-weight: 700;
+    line-height: 1.1;
+    color: var(--slate-900);
+    margin: 0;
+    letter-spacing: -0.02em;
+}
+
+.kpi-label {
+    font-size: clamp(0.5rem, 0.75vw, 0.7rem);
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--slate-600);
+    margin: 0;
+}
+
+/* KPI Card alignment rows */
+.kpi-value-row {
+    min-height: 0;
+    display: flex;
+    align-items: baseline;
+    justify-content: center;
+    padding-top: 0.25rem;
+}
+
+.kpi-label-row {
+    margin-top: 0.25rem;
+    text-align: center;
+}
+
+/* KPI cards — compact, centered, stretch to match tallest */
+.kpi-card-row .card {
+    flex: 1 1 auto;
+    text-align: center;
+}
+
+.kpi-card-row .card .card-header {
+    text-align: center;
+}
+
+.kpi-card-row .card .card-body {
+    flex: 1 1 auto;
+    align-items: center;
+    justify-content: center;
+    padding: 0.25rem 1rem 0.5rem;
+}
+
+/* KPI row itself should not grow */
+.kpi-card-row {
+    flex: 0 0 auto;
+    margin-bottom: 0;
+}
+
+/* Ensure KPI row columns stretch cards to equal height */
+.kpi-card-row bslib-layout-columns {
+    align-items: stretch;
+}
+
+.kpi-card-row bslib-layout-columns > .bslib-grid-item {
+    display: flex;
+    flex-direction: column;
+}
+
+/* Trend Indicator - Triangle Style */
+.trend-indicator {
+    font-weight: 700;
+    font-size: clamp(0.85rem, 1.5vw, 1.25rem);
+    margin-left: 0.5rem;
+    display: inline-block;
+    line-height: 1;
+}
+
+.trend-indicator.up {
+    color: var(--success);
+}
+
+.trend-indicator.down {
+    color: var(--danger);
+}
+
+/* KPI Health Status Icons */
+.kpi-status {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 1.75rem;
+    height: 1.75rem;
+    border-radius: 50%;
+    font-size: 0.85rem;
+    font-weight: 700;
+    margin-left: 0.75rem;
+    vertical-align: middle;
+    line-height: 1;
+}
+
+.kpi-status.healthy {
+    background-color: #d1fae5;
+    color: #065f46;
+}
+
+.kpi-status.warning {
+    background-color: #fef3c7;
+    color: #92400e;
+}
+
+.kpi-status.danger {
+    background-color: #fee2e2;
+    color: #991b1b;
+}
+
+/* Table Styling */
+.table {
+    font-size: clamp(0.65rem, 0.9vw, 0.875rem);
+    color: var(--slate-700);
+}
+
+.table thead {
+    background-color: var(--slate-100);
+    border-bottom: 2px solid var(--slate-200);
+}
+
+.table thead th {
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--slate-900);
+    padding: clamp(0.4rem, 0.8vh, 0.875rem) clamp(0.5rem, 1vw, 1rem);
+    font-size: clamp(0.55rem, 0.8vw, 0.75rem);
+}
+
+.table tbody tr {
+    transition: background-color 0.2s ease;
+    border-bottom: 1px solid var(--slate-200);
+}
+
+.table tbody tr:nth-child(odd) {
+    background-color: var(--slate-50);
+}
+
+.table tbody tr:hover {
+    background-color: var(--slate-100);
+}
+
+.table tbody td {
+    padding: clamp(0.3rem, 0.7vh, 0.875rem) clamp(0.5rem, 1vw, 1rem);
+    vertical-align: middle;
+}
+
+/* Input and Slider Styling */
+input[type="range"] {
+    cursor: pointer;
+}
+
+input[type="range"]:hover {
+    filter: brightness(0.95);
+}
+
+input[type="text"],
+input[type="select"],
+select {
+    border: 1px solid var(--slate-300);
+    border-radius: 0.375rem;
+    padding: 0.5rem 0.75rem;
+    font-size: 0.875rem;
+    transition: all 0.2s ease;
+}
+
+input[type="text"]:focus,
+input[type="select"]:focus,
+select:focus {
+    outline: none;
+    border-color: var(--primary);
+    box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.1), 0 0 0 1px var(--primary);
+}
+
+/* Layout — viewport-fit, no scroll */
+.page-fillable {
+    padding: 0.75rem 1rem;
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    gap: 0.85rem;
+}
+
+/* Sidebar layout main panel — override bslib's 1.5rem gap */
+.bslib-sidebar-layout > .main.bslib-gap-spacing {
+    gap: clamp(0.4rem, 1vh, 0.85rem) !important;
+    padding: clamp(0.4rem, 0.8vh, 0.75rem) clamp(0.5rem, 1vw, 1rem);
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+}
+
+/* Transitions for micro-interactions — scoped to interactive elements */
+a,
+button,
+input,
+select,
+textarea,
+.btn,
+.nav-link {
+    transition: color 0.2s ease, background-color 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+/* Remove default bslib sidebar layout border */
+.bslib-sidebar-layout {
+    border: none !important;
+}
+
+/* Sidebar collapse-toggle button */
+.bslib-sidebar-layout > .collapse-toggle {
+    background-color: white;
+    border: 1px solid var(--slate-200);
+    border-radius: 0.5rem;
+    width: 1.75rem;
+    height: 1.75rem;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
+    z-index: 10;
+    transition: background-color 0.2s ease, border-color 0.2s ease,
+                box-shadow 0.2s ease;
+    top: 0.55rem;
+}
+
+.bslib-sidebar-layout > .collapse-toggle:hover {
+    background-color: var(--slate-50);
+    border-color: var(--slate-400);
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
+}
+
+.bslib-sidebar-layout > .collapse-toggle > .collapse-icon {
+    color: var(--slate-600);
+}
+
+/* When collapsed, nudge title right so it clears the toggle */
+.bslib-sidebar-layout.sidebar-collapsed > .main h2:first-child {
+    padding-left: 2.25rem;
+    transition: padding-left 0.3s ease;
+}
+
+/* Remove outer container padding so content spans full width */
+body > .container-fluid {
+    padding-left: 0 !important;
+    padding-right: 0 !important;
+}
+
+/* Navbar styling */
+.navbar {
+    background-color: white;
+    border-bottom: 1px solid var(--slate-200);
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
+}
+
+.nav-link {
+    font-weight: 500;
+    color: var(--slate-600);
+    transition: color 0.2s ease;
+}
+
+.nav-link:hover,
+.nav-link.active {
+    color: var(--primary);
+}
+
+/* Vertical section labels */
+.section-label {
+    writing-mode: vertical-rl;
+    text-orientation: upright;
+    color: white;
+    font-weight: bold;
+    border-radius: 6px;
+    text-align: center;
+    letter-spacing: 1px;
+    font-size: 0.8rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    white-space: nowrap;
+    flex-shrink: 0;
+    overflow: hidden;
+    padding: 0.5rem 0;
+}
+
+.section-label-blue {
+    background-color: var(--section-blue);
+}
+
+.section-label-red {
+    background-color: var(--section-red);
+}
+
+/* Footer styling */
+.footer-container {
+    padding: 0.4rem 0;
+    margin-top: 0;
+    color: var(--slate-600);
+    font-size: 0.8rem;
+    border-top: 1px solid var(--slate-200);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.footer-container p {
+    margin: 0;
+}
+
+.footer-container a {
+    color: var(--primary);
+    text-decoration: none;
+}
+
+.footer-container a:hover {
+    text-decoration: underline;
+}
+
+.footer-container strong {
+    color: var(--slate-900);
+}
+
+/* Grid sections — flex to fill viewport */
+.grid-section {
+    display: flex;
+    align-items: stretch;
+    gap: 0.75rem;
+    width: 100%;
+    margin-bottom: 0.5rem;
+    flex: 1 1 0;
+    min-height: 0;
+    padding: 0.6rem;
+    border-radius: 0.75rem;
+}
+
+/* Section label fixed width in flex row */
+.grid-section > .section-label {
+    width: 40px;
+    flex-shrink: 0;
+}
+
+/* Layout_columns wrapper fills remaining space */
+.grid-section > :not(.section-label) {
+    flex: 1 1 0;
+    min-width: 0;
+    margin-bottom: 0 !important;
+}
+
+/* Blue group (Profitability) */
+.grid-section-blue {
+    background-color: rgba(41, 128, 185, 0.08);
+    box-shadow: 0 0 0 1px rgba(41, 128, 185, 0.2),
+                0 2px 10px rgba(41, 128, 185, 0.16);
+}
+
+/* Red group (Financial Health) */
+.grid-section-red {
+    background-color: rgba(192, 57, 43, 0.08);
+    box-shadow: 0 0 0 1px rgba(192, 57, 43, 0.2),
+                0 2px 10px rgba(192, 57, 43, 0.16);
+}
+
+/* Compact grid section (KPI rows — don't grow) */
+.grid-section-compact {
+    flex: 0 0 auto;
+}
+
+/* Cards inside the grid take full width and height */
+.grid-section .shiny-layout-column {
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+}
+
+/* Shiny layout_columns rows should fill height */
+.grid-section .row {
+    flex: 1 1 0;
+    min-height: 0;
+    margin-bottom: 0 !important;
+    --bs-gutter-y: 0;
+}
+
+/* Column children inside layout_columns fill their cell */
+.grid-section .row > [class*="col-"] {
+    display: flex;
+    flex-direction: column;
+}
+
+/* Plotly chart containers fill available space */
+.card .plotly,
+.card .js-plotly-plot,
+.card .plotly.html-widget,
+.card .shiny-report-size {
+    flex: 1 1 0;
+    min-height: 0;
+    width: 100%;
+    height: 100%;
+}
+
+/* Kill bslib default vertical spacing inside page content areas;
+   let our gap property handle uniform spacing instead */
+.page-fillable,
+.bslib-sidebar-layout > .main {
+    --bslib-mb-spacer: 0;
+}
+
+.page-fillable .bslib-mb-spacing,
+.bslib-sidebar-layout > .main .bslib-mb-spacing {
+    margin-bottom: 0 !important;
+}
+
+.page-fillable > *,
+.bslib-sidebar-layout > .main > * {
+    margin-bottom: 0 !important;
+}
+
+/* layout_columns at page level — fill remaining space equally */
+.page-fillable > bslib-layout-columns,
+.bslib-sidebar-layout > .main > bslib-layout-columns {
+    flex: 1 1 0;
+    min-height: 0;
+}
+
+/* KPI row wrapper should NOT grow */
+.page-fillable > .kpi-card-row,
+.bslib-sidebar-layout > .main > .kpi-card-row {
+    flex: 0 0 auto;
+}
+
+/* Column children inside layout_columns fill their cell */
+.page-fillable bslib-layout-columns > .bslib-grid-item,
+.bslib-sidebar-layout > .main bslib-layout-columns > .bslib-grid-item {
+    display: flex;
+    flex-direction: column;
+}
+
+/* fin-chat: data card — compact, no grow */
+.page-fillable > .card:has(.dataTable) {
+    flex: 0 0 auto;
+    max-height: 45vh;
+    overflow: hidden;
+}
+
+/* fin-chat: Download CSV button */
+.btn-csv-download.shiny-download-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+    width: auto;
+    padding: 0.3rem 0.75rem;
+    font-family: 'DM Sans', sans-serif;
+    font-size: 0.8rem;
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    color: var(--slate-600);
+    background-color: white;
+    border: 1px solid var(--slate-200);
+    border-radius: 6px;
+    cursor: pointer;
+    text-decoration: none;
+    transition: color 0.15s ease, border-color 0.15s ease, box-shadow 0.15s ease;
+}
+
+.btn-csv-download.shiny-download-link:hover {
+    color: var(--slate-900);
+    border-color: var(--slate-400);
+    box-shadow: 0 1px 4px rgba(0, 0, 0, 0.08);
+}
+
+.btn-csv-download.shiny-download-link:active,
+.btn-csv-download.shiny-download-link:focus {
+    color: var(--slate-900);
+    border-color: var(--slate-400);
+    box-shadow: 0 0 0 2px rgba(37, 99, 235, 0.12);
+    outline: none;
+    background-color: white;
+}
+
+/* fin-chat: undo aggressive card styles inside sidebar/chat */
+.sidebar .card {
+    flex: 0 0 auto;
+    min-height: auto;
+}
+
+.sidebar .card-body {
+    flex: 0 0 auto;
+    min-height: auto;
+    overflow: visible;
+    justify-content: flex-start;
+}
+
+.sidebar .card-header {
+    white-space: normal;
+    word-wrap: break-word;
+    padding: 0.5rem 1rem;
+}


### PR DESCRIPTION
## Summary
- Add `www/custom_styles.css` adapted from `assets/custom_styles.css`
- Replace Altair/Vega-specific selectors (`.vega-embed`, `.jupyter-widgets`, `.widget-subarea`) with plotly equivalents (`.plotly`, `.js-plotly-plot`, `.plotly.html-widget`)
- Update fin-chat data card selector for DT (`.dataTable`) instead of `.shiny-data-grid`
- Keep all CSS variables, card styles, KPI styles, status icons, trend indicators, section labels, sidebar, navbar, footer

## Test plan
- [ ] App renders with correct styling
- [ ] Plotly charts fill their card containers
- [ ] KPI cards, status icons, trend indicators match Python version visually
- [ ] fin-chat data card stays compact

Closes #6